### PR TITLE
fix(FilesList): scan a directory argument itself, not its parent

### DIFF
--- a/src/FilesList.cpp
+++ b/src/FilesList.cpp
@@ -14,6 +14,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <filesystem>
 #include <dirent.h>
 #include <unistd.h>
 
@@ -25,22 +26,6 @@ cFilesList::cFilesList(bool allValid, bool recursive)
 
 namespace
 {
-    std::string GetBaseDir(const char* path)
-    {
-        std::string dir = path;
-        size_t pos = dir.find_last_of('/');
-        if (std::string::npos != pos)
-        {
-            dir = dir.substr(0, pos);
-        }
-        else
-        {
-            dir = ".";
-        }
-
-        return dir;
-    }
-
     int Filter(const dirent* dir)
     {
         // skip . and ..
@@ -52,13 +37,29 @@ namespace
 
 void cFilesList::parseDirectory(const std::string& current)
 {
-    const auto localCopy = current;
-    auto path = localCopy.c_str();
+    // Copy first: `current` may reference an element of m_files, and
+    // scanDirectory() can reallocate that vector.
+    const std::string target = current;
 
-    scanDirectory(GetBaseDir(path));
+    // A directory argument is scanned as-is; a file argument scans the folder
+    // that contains it. Ask the filesystem which one it is instead of guessing
+    // from the string.
+    std::error_code ec;
+    const std::filesystem::path path(target);
+    std::filesystem::path root = std::filesystem::is_directory(path, ec)
+        ? path
+        : path.parent_path();
 
+    // A bare filename with no directory component has an empty parent; scan the
+    // current directory, as the previous string-based helper did.
+    if (root.empty())
+    {
+        root = ".";
+    }
+
+    scanDirectory(root.string());
     sortList();
-    locateFile(path);
+    locateFile(target.c_str());
 }
 
 void cFilesList::parseDir()


### PR DESCRIPTION
## Problem

A bare directory argument (`sviewgl tests/`, `sviewgl -r tests/`) showed nothing - no error, no images. `parseDirectory` derived the folder to scan with `GetBaseDir`, which strips the last path component and always returns the *parent*. That is right for a file argument (scan the file's folder so siblings are navigable) but wrong for a directory, which then scanned the parent - usually with no images - so the viewer fell back to the "not available" placeholder.

## Fix

Ask the filesystem instead of guessing from the string: `std::filesystem::is_directory` distinguishes a directory (scanned as-is) from a file (scan its containing folder via `path::parent_path`). `GetBaseDir` had no other user and is removed.

## Testing (macOS)

- `sviewgl tests/` and `sviewgl <abs>/tests` now list the directory (info bar shows `1 / 59`); `-r` scans it recursively through the same path.
- `sviewgl tests/file.jpg` unchanged - shows the file.
- Release build clean. First use of `<filesystem>` in the project (needs macOS 10.15+ / a modern libstdc++ on Linux - already implied by the toolchain; no minimum version is pinned).